### PR TITLE
add new input to prepend key prefix

### DIFF
--- a/serverless.js
+++ b/serverless.js
@@ -131,7 +131,8 @@ class AwsS3 extends Component {
         await uploadDir(
           this.state.accelerated ? clients.accelerated : clients.regular,
           name,
-          inputs.dir
+          inputs.dir,
+          { keyPrefix: inputs.keyPrefix }
         )
       }
     } else if (inputs.file && (await utils.fileExists(inputs.file))) {

--- a/utils.js
+++ b/utils.js
@@ -59,7 +59,7 @@ const ensureBucket = async (s3, name, debug) => {
   }
 }
 
-const uploadDir = async (s3, bucketName, dirPath) => {
+const uploadDir = async (s3, bucketName, dirPath, options) => {
   const items = await new Promise((resolve, reject) => {
     try {
       resolve(klawSync(dirPath))
@@ -74,9 +74,15 @@ const uploadDir = async (s3, bucketName, dirPath) => {
       return
     }
 
+    let key = path.relative(dirPath, item.path)
+
+    if (options.keyPrefix) {
+      key = path.posix.join(options.keyPrefix, key)
+    }
+
     const itemParams = {
       Bucket: bucketName,
-      Key: path.relative(dirPath, item.path),
+      Key: key,
       Body: fs.readFileSync(item.path)
     }
     const file = path.basename(item.path)


### PR DESCRIPTION
**Motivation**

Sometimes you may want to have a path prefix for the uploaded S3 keys that doesn't reflect the structure of your filesystem. 

For example:

```
# filesystem
build-abc
  - asset-1.js
  - asset-2.js
```

But on S3 you want a slightly different structure:

 ```
# S3
assets
  - asset-1.js
  - asset-2.js
```

Currently that's not possible using the `upload` functionality without having to cp files around which may be expensive for big directories.

**Proposal**

Add a new input `keyPrefix` which prepends the prefix to each file uploaded:

```js
bucket.upload({
        dir: "./build-abc",
        keyPrefix: "assets"
      }),
``` 


