### PR TITLE
Fix directory uploading on windows by replacing backslashes with forw…

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -80,6 +80,11 @@ const uploadDir = async (s3, bucketName, dirPath, options) => {
       key = path.posix.join(options.keyPrefix, key)
     }
 
+    // convert backslashes to forward slashes on windows
+    if (path.sep === '\\') {
+      key = key.replace(/\\/g, '/')
+    }
+
     const itemParams = {
       Bucket: bucketName,
       Key: key,


### PR DESCRIPTION
…ard slashes.

On POSIX systems and S3, backslashes are considered to be part of the file name.

Fixes issue #1 