### PR TITLE
Bucket CORS functionality & usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ myBucket:
   inputs:
     accelerated: false # default is true. Enables upload acceleartion for the bucket
     region: us-east-1
+    cors:
+      CORSRules:
+      - AllowedHeaders:
+        - "*"
+        AllowedMethods:
+        - PUT
+        - POST
+        - DELETE
+        AllowedOrigins:
+        - http://www.example.com
+        MaxAgeSeconds: 3000
+
 ```
 
 ### 4. Deploy

--- a/serverless.js
+++ b/serverless.js
@@ -46,7 +46,7 @@ class AwsS3 extends Component {
 
     if (config.cors) {
       this.context.debug(
-        `Setting cors to "${JSON.stringify(config.cors)}" for bucket ${config.name}.`
+        `Setting cors for bucket ${config.name}.`
       )
       await configureCors(clients.regular, config.name, config.cors, this.context.debug)
     }

--- a/serverless.js
+++ b/serverless.js
@@ -9,7 +9,8 @@ const {
   uploadDir,
   packAndUploadDir,
   uploadFile,
-  ensureBucket
+  ensureBucket,
+  configureCors
 } = require('./utils')
 
 const defaults = {
@@ -41,6 +42,13 @@ class AwsS3 extends Component {
         `Setting acceleration to "${config.accelerated}" for bucket ${config.name}.`
       )
       await accelerateBucket(clients.regular, config.name, config.accelerated)
+    }
+
+    if (config.cors) {
+      this.context.debug(
+        `Setting cors to "${JSON.stringify(config.cors)}" for bucket ${config.name}.`
+      )
+      await configureCors(clients.regular, config.name, config.cors, this.context.debug)
     }
 
     // todo we probably don't need this logic now that we auto generate names

--- a/utils.js
+++ b/utils.js
@@ -214,6 +214,19 @@ const deleteBucket = async (s3, bucketName) => {
   }
 }
 
+const configureCors = async (s3, bucketName, config) => {
+  const params = { Bucket: bucketName, CORSConfiguration: config }
+  try {
+    await s3.putBucketCors(params).promise()
+  } catch (e) {
+    if (e.code === 'NoSuchBucket') {
+      await utils.sleep(2000)
+      return configureCors(s3, bucketName, config)
+    }
+    throw e
+  }
+}
+
 module.exports = {
   getClients,
   uploadDir,
@@ -223,5 +236,6 @@ module.exports = {
   accelerateBucket,
   deleteBucket,
   bucketCreation,
-  ensureBucket
+  ensureBucket,
+  configureCors
 }


### PR DESCRIPTION
Backwards compatible (cors input parameters can be left out). Added example on README. For all parameters see https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putBucketCors-property .


Closes https://github.com/serverless/components/issues/500