### PR TITLE
Cache-control headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ await bucket.upload({ file: './my-file.txt' })
 
 ```
 
+[Cache-control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) headers can also be set:
+
+```js
+
+// upload directory, setting cache-control headers
+await bucket.upload({ dir: './my-files', cacheControl: 'max-age=86400' })
+
+// upload file, setting cache-control header
+await bucket.upload({ file: './my-file.txt', cacheControl: 'max-age=86400' })
+```
+
 For a full example on how this component could be used, [take a look at how the website component is using it](https://github.com/serverless-components/website/).
 
 &nbsp;

--- a/serverless.js
+++ b/serverless.js
@@ -132,7 +132,8 @@ class AwsS3 extends Component {
           s3: this.state.accelerated ? clients.accelerated : clients.regular,
           bucketName: name,
           dirPath: inputs.dir,
-          key: inputs.key || `${defaultKey}.zip`
+          key: inputs.key || `${defaultKey}.zip`,
+          cacheControl: inputs.cacheControl,
         })
       } else {
         this.context.debug(`Uploading directory ${inputs.dir} to bucket ${name}`)
@@ -141,6 +142,7 @@ class AwsS3 extends Component {
           this.state.accelerated ? clients.accelerated : clients.regular,
           name,
           inputs.dir,
+          inputs.cacheControl,
           { keyPrefix: inputs.keyPrefix }
         )
       }
@@ -152,7 +154,8 @@ class AwsS3 extends Component {
         s3: this.state.accelerated ? clients.accelerated : clients.regular,
         bucketName: name,
         filePath: inputs.file,
-        key: inputs.key || path.basename(inputs.file)
+        key: inputs.key || path.basename(inputs.file),
+        cacheControl: inputs.cacheControl,
       })
 
       this.context.debug(


### PR DESCRIPTION
Resolves #6. Allows for cacheControl headers to be added as part of the input. For example:

```
await s3Bucket.upload({ file: './test.txt', cacheControl: 'public, max-age=31536000, immutable' });
```
This works for folders as well:

```
await s3Bucket.upload({ dir: './test.txt', cacheControl: 'public, max-age=31536000, immutable' });
```